### PR TITLE
ci: put everything in the same group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,17 +8,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/.github" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "tuesday"
-      time: "18:00"
+      time: "23:00"
       timezone: "Asia/Taipei"
     groups:
-      actions:
+      github-actions:
         patterns:
-          - "actions/*"
-      docker:
-        patterns:
-          - "docker/*"
+          - "*"


### PR DESCRIPTION
I don't know why it doesn't work :(

CI logs:
```
2025/02/04 10:26:09 INFO <job_958773676> Job definition: {"job":{"allowed-updates":[{"dependency-type":"direct","update-type":"all"}],"commit-message-options":{"prefix":null,"prefix-development":null,"include-scope":null},"credentials-metadata":[{"type":"git_source","host":"github.com"}],"debug":null,"dependencies":null,"dependency-groups":[{"name":"actions","rules":{"patterns":["actions/*"]}},{"name":"docker","rules":{"patterns":["docker/*"]}}],"dependency-group-to-refresh":null,"existing-pull-requests":[],"existing-group-pull-requests":[],"experiments":{"record-ecosystem-versions":true,"record-update-job-unknown-error":true,"proxy-cached":true,"move-job-token":true,"dependency-change-validation":true,"nuget-install-dotnet-sdks":true,"nuget-native-analysis":true,"nuget-use-direct-discovery":true,"enable-file-parser-python-local":true,"npm-fallback-version-above-v6":true,"npm-v6-deprecation-warning":true,"npm-v6-unsupported-error":true,"python-3-8-deprecation-warning":true,"lead-security-dependency":true,"enable-record-ecosystem-meta":true,"enable-shared-helpers-command-timeout":true,"enable-fix-for-pnpm-no-change-error":true,"enable-engine-version-detection":true,"avoid-duplicate-updates-package-json":true,"allow-refresh-for-existing-pr-dependencies":true},"ignore-conditions":[],"lockfile-only":false,"max-updater-run-time":2700,"package-manager":"github_actions","proxy-log-response-body-on-auth-failure":true,"requirements-update-strategy":null,"reject-external-code":false,"security-advisories":[],"security-updates-only":false,"source":{"provider":"github","repo":"second-state/wasmmark","branch":null,"directory":"/.github","api-endpoint":"https://api.github.com/","hostname":"github.com"},"updating-a-pull-request":false,"update-subdependencies":false,"vendor-dependencies":false,"enable-beta-ecosystems":false,"repo-private":false}}
```

```
updater | 2025/02/04 10:26:11 WARN <job_958773676> Please check your configuration as there are groups where no dependencies match:
- actions
- docker

This can happen if:
- the group's 'pattern' rules are misspelled
- your configuration's 'allow' rules do not permit any of the dependencies that match the group
- the dependencies that match the group rules have been removed from your project

  proxy | 2025/02/04 10:26:11 [008] POST /update_jobs/958773676/update_dependency_list
  proxy | 2025/02/04 10:26:11 [008] 204 /update_jobs/958773676/update_dependency_list
  proxy | 2025/02/04 10:26:11 [010] POST /update_jobs/958773676/increment_metric
  proxy | 2025/02/04 10:26:11 [010] 204 /update_jobs/958773676/increment_metric
updater | 2025/02/04 10:26:11 INFO <job_958773676> Starting grouped update job for second-state/wasmmark
2025/02/04 10:26:11 INFO <job_958773676> Found 2 group(s).
updater | 2025/02/04 10:26:11 WARN <job_958773676> Skipping update group for 'actions' as it does not match any allowed dependencies.
updater | 2025/02/04 10:26:11 INFO <job_958773676> Marking group 'actions' as handled.
updater | 2025/02/04 10:26:11 INFO <job_958773676> Adding dependencies as handled: ().
updater | 2025/02/04 10:26:11 WARN <job_958773676> Skipping update group for 'docker' as it does not match any allowed dependencies.
updater | 2025/02/04 10:26:11 INFO <job_958773676> Marking group 'docker' as handled.
2025/02/04 10:26:11 INFO <job_958773676> Adding dependencies as handled: ().
  proxy | 2025/02/04 10:26:11 [012] PATCH /update_jobs/958773676/mark_as_processed
  proxy | 2025/02/04 10:26:12 [012] 204 /update_jobs/958773676/mark_as_processed
updater | 2025/02/04 10:26:12 INFO <job_958773676> Finished job processing
```